### PR TITLE
CMD: bundle exec ridgepole -c config/database.yml --export --output d…

### DIFF
--- a/db/Schemafile
+++ b/db/Schemafile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+create_table "direct_messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  t.bigint "sender_id"
+  t.bigint "reciever_id"
+  t.text "body"
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+  t.index ["reciever_id"], name: "index_direct_messages_on_reciever_id"
+  t.index ["sender_id"], name: "index_direct_messages_on_sender_id"
+end
+
+create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  t.string "email"
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+end
+
+add_foreign_key "direct_messages", "users", column: "reciever_id", name: "fk_rails_4b167b49c1"
+add_foreign_key "direct_messages", "users", column: "sender_id", name: "fk_rails_a0333513a1"


### PR DESCRIPTION
## Schemafile作成
```sh
bundle exec ridgepole -c config/database.yml --export --output db/Schemafile --dump-with-default-fk-name
```
上記コマンドでデフォルトの外部キー制約名も付与したSchemafileを作成している

## apply
動作しない
デフォルトのname指定は差分チェック時に考慮しないようになっており、カラム指定も考慮されないため、重複とみなされエラーになる

```sh
sample-rails-app> bundle exec ridgepole -c config/database.yml --apply -f db/Schemafile
Apply `db/Schemafile`
[ERROR] Foreign Key `direct_messages(["direct_messages", "users"])` already defined
        /Users/nagamoto/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/ridgepole-0.7.7/lib/ridgepole/dsl_parser/context.rb:92:in `add_foreign_key'
sample-rails-app> bundle exec ridgepole -c config/database.yml --apply -f db/Schemafile
Apply `db/Schemafile`
[ERROR] Foreign Key `direct_messages(["direct_messages", "users"])` already defined
        /Users/nagamoto/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/ridgepole-0.7.7/lib/ridgepole/dsl_parser/context.rb:92:in `add_foreign_key'
nagamoto@eimotoochuunoMacBook-puro ~/o/sample-rails-app> 
```