### PR TITLE
CMD: bundle exec ridgepole -c config/database.yml --export --output d…

### DIFF
--- a/db/Schemafile
+++ b/db/Schemafile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+create_table "direct_messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  t.bigint "sender_id"
+  t.bigint "reciever_id"
+  t.text "body"
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+  t.index ["reciever_id"], name: "index_direct_messages_on_reciever_id"
+  t.index ["sender_id"], name: "index_direct_messages_on_sender_id"
+end
+
+create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  t.string "email"
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+end
+
+add_foreign_key "direct_messages", "users", column: "reciever_id"
+add_foreign_key "direct_messages", "users", column: "sender_id"


### PR DESCRIPTION
## Schemafile作成
```sh
bundle exec ridgepole -c config/database.yml --export --output db/Schemafile
```
上記コマンドでDBからSchemafileを作成している

## apply
動作しない
columnオプションで与える値が異なっていても実行時前の差分チェックでは区別しておらず、
同じ外部キー制約を複数回追加しようとしたと判断し、エラーが発生する
https://github.com/winebarrel/ridgepole/blob/v0.7.7/lib/ridgepole/dsl_parser/context.rb#L85

```sh
sample-rails-app> bundle exec ridgepole -c config/database.yml --apply -f db/Schemafile
Apply `db/Schemafile`
[ERROR] Foreign Key `direct_messages(["direct_messages", "users"])` already defined
        /Users/nagamoto/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/ridgepole-0.7.7/lib/ridgepole/dsl_parser/context.rb:86:in `add_foreign_key'
sample-rails-app> bundle exec ridgepole -c config/database.yml --apply -f db/Schemafile
Apply `db/Schemafile`
[ERROR] Foreign Key `direct_messages(["direct_messages", "users"])` already defined
        /Users/nagamoto/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/ridgepole-0.7.7/lib/ridgepole/dsl_parser/context.rb:86:in `add_foreign_key'
```